### PR TITLE
Fix env variable typo

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.10-slim-bookworm
 
 # Set environment variables
-ENV PYTHONDONDONTWRITEBYTECODE=1 \
+ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \
     PIP_NO_CACHE_DIR=1 \


### PR DESCRIPTION
## Summary
- fix the PYTHONDONTWRITEBYTECODE variable spelling in server Dockerfile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f32e48108328828ac2120f7a8a35