### PR TITLE
Sanitize credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,17 +32,17 @@ services:
       # variables para producción (se usan en server/app/core/config.py)
       - MONGO_URI=mongodb://mongo:27017/encodergroup
       - ENVIRONMENT=production
-      - JWT_SECRET=encodergroup_jwt_secret_key_secure_2023
+      - JWT_SECRET=your_jwt_secret_key
       - JWT_ALGORITHM=HS256
       - ACCESS_TOKEN_EXPIRE_MINUTES=10080   # 7 días
-      - SMTP_HOST=mail.encodergroup.cl
+      - SMTP_HOST=smtp.example.com
       - SMTP_PORT=465
-      - SMTP_USER=noreply@encodergroup.cl
-      - SMTP_PASSWORD=.3H*qU8MI&?g
+      - SMTP_USER=noreply@example.com
+      - SMTP_PASSWORD=your_smtp_password
       - SMTP_SSL=true
       - SMTP_VERIFY_SSL=false
       - CLIENT_URL=http://localhost             # para enlaces de verificación
-      - ADMIN_EMAIL=admin@encodergroup.cl
+      - ADMIN_EMAIL=admin@example.com
       - PYTHONUNBUFFERED=1
     volumes:
       - ./server/app:/app/app

--- a/server/test_email.py
+++ b/server/test_email.py
@@ -5,13 +5,13 @@ from email.mime.multipart import MIMEMultipart
 from email.header import Header
 
 # Configuración SMTP
-SMTP_HOST = 'mail.encodergroup.cl'
+SMTP_HOST = 'smtp.example.com'
 SMTP_PORT = 465
-SMTP_USER = 'noreply@encodergroup.cl'
-SMTP_PASSWORD = '.3H*qU8MI&?g'
+SMTP_USER = 'noreply@example.com'
+SMTP_PASSWORD = 'your_smtp_password'
 
 # Dirección de mail-tester.com (reemplaza con la que recibas del sitio)
-TARGET_EMAIL = 'test-axosh9lpa@srv1.mail-tester.com'
+TARGET_EMAIL = 'your-test-email@example.com'
 
 # Crear mensaje
 msg = MIMEMultipart('alternative')


### PR DESCRIPTION
## Summary
- scrub sensitive SMTP credentials from `test_email.py`
- use placeholder credentials in docker compose config

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848f4b4bce48328b942eb3f826b4d7a